### PR TITLE
Spot instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # v1.0.0 - <date>
 
 Added
-- Add Something you added
+- Exposed paramters to configure Azure Spot instanaces
+  of azurerm_linux_virtual_machine and azurerm_windows_virtual_machine
+  Terraform ressources, so that the Spot instances can be deployed 
+  with this module

--- a/resources.virtual.machine.tf
+++ b/resources.virtual.machine.tf
@@ -80,6 +80,9 @@ resource "azurerm_linux_virtual_machine" "linux_vm" {
   location                        = local.location
   resource_group_name             = local.resource_group_name
   size                            = var.virtual_machine_size
+  priority                        = var.use_spot_instances ? "Spot": "Regular"
+  eviction_policy                 = var.use_spot_instances ? var.vm_eviction_policy : null
+  max_bid_price                   = var.use_spot_instances ? var.max_bid_price : null
   admin_username                  = var.admin_username
   admin_password                  = var.disable_password_authentication == false && var.admin_password == null ? element(concat(random_password.passwd.*.result, [""]), 0) : var.admin_password
   disable_password_authentication = var.disable_password_authentication
@@ -158,6 +161,9 @@ resource "azurerm_windows_virtual_machine" "win_vm" {
   location                     = local.location
   resource_group_name          = local.resource_group_name
   size                         = var.virtual_machine_size
+  priority                     = var.use_spot_instances ? "Spot": "Regular"
+  eviction_policy              = var.use_spot_instances ? var.vm_eviction_policy : null
+  max_bid_price                = var.use_spot_instances ? var.max_bid_price : null
   admin_username               = var.admin_username
   admin_password               = var.admin_password == null ? element(concat(random_password.passwd.*.result, [""]), 0) : var.admin_password
   network_interface_ids        = [element(concat(azurerm_network_interface.nic.*.id, [""]), count.index)]

--- a/variables.virtual.machine.tf
+++ b/variables.virtual.machine.tf
@@ -85,6 +85,28 @@ variable "admin_ssh_key_data" {
   default     = null
 }
 
+variable "use_spot_instances" {
+  description = "Should spot instances be used insted of regular VM. Default is false."
+  default = false
+  type = bool
+}
+
+variable "vm_eviction_policy" {
+  description = "Specifies what should happen when the Virtual Machine is evicted. Only relevant if use_spot_instances is set to true. Default is Delete."
+  type = string
+  default = "Delete"
+  validation {
+    condition     = contains(["delete", "deallocates"], lower(var.vm_eviction_policy))
+    error_message = "Allowed values for virtual_machine_eviction_policy are \"delete\" or \"deallocates\"."
+  }
+}
+
+variable "max_bid_price" {
+  type = number
+  description = "Specifies the maximum price that should be paid for this VM, in US Dollars. Only relevant if use_spot_instances is set to true. Default is -1, which means that the Virtual Machine should not be evicted for price reasons."
+  default = -1
+}
+
 ##############################
 # VM Network Configuration  ##
 ##############################


### PR DESCRIPTION
## Describe your changes

Exposed the proper arguments of azurerm_linux_virtual_machine and azurerm_windows_virtual_machine terraform resources, in order to allow for creating spot instances. 

Also required variables have been added to the variables.virtual.machine.tf, so that a module user can configure spot instances like described in the referenced issue. 

## Issue number

#19 

## Checklist before requesting a review
- [x ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

(Sorry, I didn't execute neither the pre-commit nor the pr-check, as I couldn't find them or any other reference to them.)

