### PR TITLE
Fixed secondary NIC ipconfig change loop

### DIFF
--- a/resources.virtual.machine.network.tf
+++ b/resources.virtual.machine.network.tf
@@ -45,7 +45,7 @@ resource "azurerm_network_interface" "secondary_nic" {
 
   ip_configuration {
     name                          = lower("ipconfig-${format("%s%s", lower(replace(local.secondary_ip_configuration_name, "/[[:^alnum:]]/", "")), count.index + 1)}")
-    primary                       = false
+    primary                       = true
     subnet_id                     = lookup(var.additional_nic_configuration, "subnet_id", null)
     private_ip_address_allocation = "Static"
     private_ip_address            = lookup(var.additional_nic_configuration, "private_ip_address", null)


### PR DESCRIPTION
## Describe your changes
Changed the secondary NIC's IPConfiguration so that it has `primary=true` rather than `primary=false` since Azure will change it to `true` after creation anyway. This stops every subsequent `teraform plan` from showing that it needs to be changed back to `false`.
## Issue number

Closes #30 

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine

Thanks for your cooperation!

