### PR TITLE
Removed file() requirement on admin_ssh_key

### DIFF
--- a/resources.virtual.machine.tf
+++ b/resources.virtual.machine.tf
@@ -104,7 +104,7 @@ resource "azurerm_linux_virtual_machine" "linux_vm" {
     for_each = var.disable_password_authentication ? [1] : []
     content {
       username   = var.admin_username
-      public_key = var.admin_ssh_key_data == null ? tls_private_key.rsa[0].public_key_openssh : file(var.admin_ssh_key_data)
+      public_key = var.admin_ssh_key_data == null ? tls_private_key.rsa[0].public_key_openssh : var.admin_ssh_key_data
     }
   }
 


### PR DESCRIPTION
Removed the file() function that forced the user to pass in a file path for the admin ssh key rather than just the key data.  This makes the VM Overlay more flexible.

## Describe your changes

## Issue number

#000

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine

Thanks for your cooperation!

